### PR TITLE
Fix: Allow partial cash payments from sale.html and record all transa…

### DIFF
--- a/templates/retail/sale.html
+++ b/templates/retail/sale.html
@@ -774,14 +774,11 @@
         // Validate cash payment
         const total = parseFloat(elements.totalPrice.textContent.replace('৳', ''));
         if (state.paymentMethod === 'cash') {
-          if (isNaN(state.amountPaid) || state.amountPaid <= 0) { // Check if it's not a number or not positive
-              alert('Please enter a valid amount paid.');
+          if (isNaN(state.amountPaid) || state.amountPaid < 0) {
+              alert('Please enter a valid (non-negative) amount paid.');
               return;
           }
-          if (state.amountPaid < total) {
-              alert(`Amount paid (৳${state.amountPaid.toFixed(2)}) is less than the total amount (৳${total.toFixed(2)}). Please pay at least ৳${total.toFixed(2)}.`);
-              return;
-          }
+          // The check for amount_paid < total has been removed to allow partial payments.
       }
     
         // Prepare sale data with payment details


### PR DESCRIPTION
…ctions

This commit addresses two related issues:
1. Enables you to make partial cash payments directly from the `sale.html` interface.
2. Ensures all initial sale payments (full or partial) are recorded as distinct transactions in the `Payment` table.

Previously:
- The `sale.html` JavaScript enforced full payment for cash sales.
- Initial payments were stored directly on the `Sale` object, not always creating a `Payment` record.

Key changes:
- `templates/retail/sale.html`:
    - Modified the `processCheckout` JavaScript function to remove the validation that required `amount_paid` to be equal to or greater than the `total` for cash payments.
    - Adjusted validation to allow `0` as a valid (non-negative) `amount_paid`.
- `retail/views.py` (`process_sale` function):
    - Removed direct setting of `amount_paid` on the `Sale` model during creation.
    - Added logic to create a `Payment` model instance for any `amount_paid` received from the frontend during the sale.
- `retail/models.py`:
    - Reviewed `Payment.save()` and `Sale.save()` methods to confirm correct updating of `Sale.amount_paid` and `Sale.payment_status` when a `Payment` is created. This interaction was confirmed to be working as expected.
- `retail/tests.py`:
    - Added a comprehensive suite of unit tests (in `ProcessSaleTests`) for the backend `process_sale` view. These tests cover scenarios including full payment, partial payment, no initial payment, and payments with discounts, ensuring correct `Payment` object creation and `Sale` status updates.