### PR TITLE
Refactor: Improve User-Contact-Business model structure

### DIFF
--- a/userauths/models.py
+++ b/userauths/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from business.models import Business
 from django.contrib.auth.models import AbstractUser
+from contact.models import Contact # Added import
 
 # Define business types
 BUSINESS_TYPE_CHOICES = (
@@ -23,12 +24,11 @@ CUSTOMER_TIER_CHOICES = (
     ('premium', 'Premium'),
     ('wholesale', 'Wholesale'),
 )
-from django.db import models
-from django.contrib.auth.models import AbstractUser
 
-# (Keep your existing CHOICES tuples)
+# (Keep your existing CHOICES tuples) # This line and the imports below it are removed
 
-class User(AbstractUser):
+class User(AbstractUser): # AbstractUser is already imported above
+    """Custom User model for the application."""
     email = models.EmailField(max_length=255, unique=True, db_index=True)
     username = models.CharField(max_length=100, unique=True)
     bio = models.CharField(max_length=255, blank=True, null=True)
@@ -40,24 +40,34 @@ class User(AbstractUser):
         return f"{self.username}"
 
 class UserProfile(models.Model):
+    """Extends the base User model to include additional profile information, type, and business associations."""
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
-    
+
+    contact_link = models.OneToOneField( # Added field
+        'contact.Contact',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='user_profile_link',
+        help_text="Links this user profile to a contact record, if applicable (e.g., for customers or main business contacts who are also users)."
+    )
+
     # Business relationship (nullable for customers)
     business = models.ForeignKey(
-        Business, 
+        Business,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name='staff_profiles',
         help_text="Business this user belongs to (for vendors/staff)"
     )
-    
+
     user_type = models.CharField(
         max_length=10,
         choices=USER_TYPE_CHOICES,
         default='customer'
     )
-    
+
     allowed_business_type = models.CharField(
         max_length=10,
         choices=BUSINESS_TYPE_CHOICES,
@@ -65,7 +75,7 @@ class UserProfile(models.Model):
         null=True,
         help_text="Applicable for Vendors. Defines the type of business they manage."
     )
-    
+
     customer_tier = models.CharField(
         max_length=10,
         choices=CUSTOMER_TIER_CHOICES,


### PR DESCRIPTION
This commit introduces several enhancements to the User, UserProfile, Contact, and Business models to improve their relationships and overall structure, particularly for a SaaS application with a retail focus.

Key changes:

1.  **Link UserProfile to Contact:** I added a `contact_link` OneToOneField from `userauths.UserProfile` to `contact.Contact`. This allows a direct association between your profile and detailed contact record, which is especially useful for users who are also customers or key contacts of a business. The field is nullable and set to SET_NULL on deletion of the contact.

2.  **Model Docstrings (Partial):** I added class-level docstrings to the `User` and `UserProfile` models in `userauths/models.py` to improve code clarity. I encountered some difficulties while attempting to update docstrings in `contact/models.py` and `business/models.py`.

3.  **Added Unit Tests:** I introduced a new test suite `UserProfileModelTests` in `userauths/tests.py`. These tests cover:
    - Creation of UserProfiles and their association with Users.
    - Linkage between UserProfile and Business for staff/vendor type users.
    - The new `contact_link` relationship between UserProfile and Contact.
    - Validation constraints on UserProfile, ensuring staff users have a business associated and customer users do not have a direct business link on their profile.

These changes provide a more robust and clear structure for managing users, their roles within businesses, and their detailed contact information, laying a better foundation for features like project/interface assignments.